### PR TITLE
Adds JUnit to the project

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+ 
+[*]
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true
+ 
+[*.{js,jsx,ts,tsx,vue,scss}]
+indent_size = 2
+ 
+[*.{jsp,java}]
+ij_visual_guides = 120
+indent_size = 4
+

--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,4 @@ hs_err_pid*
 *~
 target/
 .idea
-
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,14 @@
       <artifactId>logback-classic</artifactId>
       <version>1.2.3</version>
     </dependency>
+
+    <!-- https://mvnrepository.com/artifact/junit/junit -->
+    <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
+        <version>4.12</version>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <build.time>${maven.build.timestamp}</build.time>
     <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
   </properties>
-  
+
   <scm>
     <url>https://github.com/Det-Kongelige-Bibliotek/ds-cumulus-export</url>
     <connection>scm:git:ssh://git@github.com:Det-Kongelige-Bibliotek/ds-cumulus-export.git</connection>
     <developerConnection>scm:git:ssh://git@github.com:Det-Kongelige-Bibliotek/ds-cumulus-export.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
-  
+
   <dependencies>
     <dependency>
       <groupId>org.sbforge</groupId>
@@ -73,6 +73,15 @@
           </execution>
         </executions>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.1</version>
+            <configuration>
+                <source>11</source>
+                <target>11</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 </project>

--- a/src/test/java/dk/kb/ds/cumulus/export/CumulusExportDummyTest.java
+++ b/src/test/java/dk/kb/ds/cumulus/export/CumulusExportDummyTest.java
@@ -1,5 +1,0 @@
-package dk.kb.ds.cumulus.export;
-
-public class CumulusExportDummyTest{
-//    Just for creating since Git won't create empty directories
-}

--- a/src/test/java/dk/kb/ds/cumulus/export/CumulusExportDummyTest.java
+++ b/src/test/java/dk/kb/ds/cumulus/export/CumulusExportDummyTest.java
@@ -1,0 +1,5 @@
+package dk.kb.ds.cumulus.export;
+
+public class CumulusExportDummyTest{
+//    Just for creating since Git won't create empty directories
+}

--- a/src/test/java/dk/kb/ds/cumulus/export/CumulusExportTest.java
+++ b/src/test/java/dk/kb/ds/cumulus/export/CumulusExportTest.java
@@ -1,0 +1,13 @@
+package dk.kb.ds.cumulus.export;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class CumulusExportTest {
+
+    @Test
+    public void testSetup() {
+        assertTrue("Basic test run with always-pass should work", true);
+    }
+}


### PR DESCRIPTION
Adds dependency on JUnit 4.12 (latest stable) to the `pom.xml` and a sample JUnit-test to check thet the whole flow works. This speeds up integration with OpenShift (Jenkins really) as unit-testing can be testes right away.