### PR TITLE
Add "fat JAR" build for command line execution (DIGISAM-131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ java -cp /usr/local/Cumulus_Java_SDK/CumulusJC.jar:target/kb-cumulus-api-0.1.5-j
 When this is done, we can run
 ```
 mvn package
-java -cp target/cumulus-export-0.1-SNAPSHOT.jar dk.kb.ds.cumulus.export.CumulusExport
+java -cp /usr/local/Cumulus_Java_SDK/CumulusJC.jar:target/cumulus-export-0.1-SNAPSHOT-jar-with-dependencies.jar dk.kb.ds.cumulus.export.CumulusExport
 ```
 
 ## Status

--- a/pom.xml
+++ b/pom.xml
@@ -1,110 +1,145 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>dk.kb.ds</groupId>
-  <artifactId>cumulus-export</artifactId>
-  <version>0.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
-  <name>cumulus-export</name>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>dk.kb.ds</groupId>
+    <artifactId>cumulus-export</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>cumulus-export</name>
 
-  <properties>
-    <build.time>${maven.build.timestamp}</build.time>
-    <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-  </properties>
+    <properties>
+        <build.time>${maven.build.timestamp}</build.time>
+        <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+        <java.main.class>dk.kb.ds.cumulus.export.CumulusExport</java.main.class>
+    </properties>
 
-  <scm>
-    <url>https://github.com/Det-Kongelige-Bibliotek/ds-cumulus-export</url>
-    <connection>scm:git:ssh://git@github.com:Det-Kongelige-Bibliotek/ds-cumulus-export.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com:Det-Kongelige-Bibliotek/ds-cumulus-export.git</developerConnection>
-    <tag>HEAD</tag>
-  </scm>
+    <scm>
+        <url>https://github.com/Det-Kongelige-Bibliotek/ds-cumulus-export</url>
+        <connection>scm:git:ssh://git@github.com:Det-Kongelige-Bibliotek/ds-cumulus-export.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com:Det-Kongelige-Bibliotek/ds-cumulus-export.git</developerConnection>
+        <tag>HEAD</tag>
+    </scm>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.sbforge</groupId>
-      <artifactId>sbforge-parent</artifactId>
-      <version>19</version>
-      <type>pom</type>
-    </dependency>
+    <dependencies>
+        <dependency>
+            <groupId>org.sbforge</groupId>
+            <artifactId>sbforge-parent</artifactId>
+            <version>19</version>
+            <type>pom</type>
+        </dependency>
 
-    <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.28</version>
-    </dependency>
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.28</version>
+        </dependency>
 
-    <!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic -->
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
-    </dependency>
- 
-      <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
-      <dependency>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-engine</artifactId>
-          <version>5.5.2</version>
-          <scope>test</scope>
-      </dependency>
+        <!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
 
-      <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-engine -->
-      <dependency>
-          <groupId>org.junit.platform</groupId>
-          <artifactId>junit-platform-engine</artifactId>
-          <version>1.5.2</version>
-          <scope>test</scope>
-      </dependency>
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.5.2</version>
+            <scope>test</scope>
+        </dependency>
 
-      <!-- Needs to be installed from https://github.com/Det-Kongelige-Bibliotek/KB-Cumulus-API with
-           mvn install -->
-      <dependency>
-          <groupId>dk.kb</groupId>
-          <artifactId>kb-cumulus-api</artifactId>
-          <version>0.1.5</version>
-      </dependency>
-      
-      <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
-      <dependency>
-          <groupId>org.yaml</groupId>
-          <artifactId>snakeyaml</artifactId>
-          <version>1.25</version>
-      </dependency>
-  </dependencies>
+        <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-engine -->
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <version>1.5.2</version>
+            <scope>test</scope>
+        </dependency>
 
-  <build>
-    <plugins>
-      <!--Create lib folder with dependencies-->
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.4.1</version>
-        <configuration>
-          <descriptors>
-            <descriptor>src/main/assembly/assembly.xml</descriptor>
-          </descriptors>
-        </configuration>
-        <executions>
-          <execution>
-            <id>make-assembly</id>
-            <!-- this is used for inheritance merges -->
-            <phase>package</phase>
-            <!-- append to the packaging phase. -->
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.1</version>
-            <configuration>
-                <source>11</source>
-                <target>11</target>
-            </configuration>
-        </plugin>
-    </plugins>
-  </build>
+        <!-- Needs to be installed from https://github.com/Det-Kongelige-Bibliotek/KB-Cumulus-API with
+             mvn install -->
+        <dependency>
+            <groupId>dk.kb</groupId>
+            <artifactId>kb-cumulus-api</artifactId>
+            <version>0.1.5</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.25</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!--Create lib folder with dependencies except CumulusJC.jar, which we are not allowed to distribute -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/assembly.xml</descriptor>
+                    </descriptors>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <!-- this is used for inheritance merges -->
+                        <phase>package</phase>
+                        <!-- append to the packaging phase. -->
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Create "fat JAR" with all dependencies except CumulusJC.jar, which we are not allowed to distribute -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>dk.kb.ds.cumulus.export.CumulusExport</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>1.2.1</version>
+                <configuration>
+                    <mainClass>dk.kb.ds.cumulus.export.CumulusExport</mainClass>
+                    <arguments>
+                        <argument></argument>
+                    </arguments>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
The generated fat JAR does not contain the CumulusJC.jar as the license
does not allow redistribution.

Secondarily this commit adjusts indents for pom.xml to 4 spaces.

This patch has been tested with `mvn package` followed by `java -cp /usr/local/Cumulus_Java_SDK/CumulusJC.jar:target/cumulus-export-0.1-SNAPSHOT-jar-with-dependencies.jar dk.kb.ds.cumulus.export.CumulusExport` as stated in the `README.md`. The result was a newly generated `solrInputFile.xml`.