### PR TITLE
Fix URLConverter

### DIFF
--- a/src/main/java/dk/kb/ds/cumulus/export/converters/URLConverter.java
+++ b/src/main/java/dk/kb/ds/cumulus/export/converters/URLConverter.java
@@ -68,12 +68,12 @@ public class URLConverter extends StringConverter {
         final String url = super.convertImpl(input);
 
         if (url == null || !verifyURL) {
-            return input;
+            return url;
         }
         boolean ok = resolves(url);
         if (ok) {
             log.debug("Server responds HTTP 200 (OK) for '" + url + "' derived from '" + input + "'");
-            return input;
+            return url;
         }
         log.warn("No resource available for '" + url + "' derived from '" + input + "'");
         return null;

--- a/src/test/java/dk/kb/ds/cumulus/export/FieldMapperTest.java
+++ b/src/test/java/dk/kb/ds/cumulus/export/FieldMapperTest.java
@@ -16,6 +16,7 @@ package dk.kb.ds.cumulus.export;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
 
 class FieldMapperTest {
@@ -30,7 +31,8 @@ class FieldMapperTest {
             "Categories", "toys\nanimals",
             "Emneord", "Old wars\nNew orders",
             "Ophav", "H.C. Andersen\nGrimm E. Ulv",
-            "Copyright", "Custom License"
+            "Copyright", "Custom License",
+            "Asset Reference", "cumulus-core-01:/Depot/DAMX/Online_Master_Arkiv/non-archival/KOB/bs_kistebilleder-2/bs000030.tif"
         );
         FieldMapper mapper = new FieldMapper();
         FieldMapper.FieldValues fieldValues = mapper.apply(record);
@@ -41,7 +43,10 @@ class FieldMapperTest {
             "title", "myTitle",
             "datetime", "2019-11-11",
             "created_date", "2019-10-04T08:05:10Z",
-            "license", "Custom License"
+            "license", "Custom License",
+            "image_preview", "https://kb-images.kb.dk/DAMJP2/online_master_arkiv/non-archival/KOB/bs_kistebilleder-2/bs000030/full/!345,2555/0/native.jpg",
+            "image_full", "https://kb-images.kb.dk/DAMJP2/online_master_arkiv/non-archival/KOB/bs_kistebilleder-2/bs000030/full/full/0/default.jpg",
+            "iiif", "https://kb-images.kb.dk/DAMJP2/online_master_arkiv/non-archival/KOB/bs_kistebilleder-2/bs000030/"
         );
 
         DSAsserts.assertMultiFieldValues(

--- a/src/test/resources/ds-cumulus-export-default-mapping.yml
+++ b/src/test/resources/ds-cumulus-export-default-mapping.yml
@@ -70,8 +70,9 @@ digisam:
           destType: "url"
           pattern: "^.*:/Depot/DAMX/Online_Master_Arkiv/(.*).tif"
           replacement: "https://kb-images.kb.dk/DAMJP2/online_master_arkiv/$1/full/!345,2555/0/native.jpg"
-          verifyPattern: "^https?://(?:www[.])?(.+)" # There is a problem with the certificate so we use plain HTTP
-          verifyReplacement: "http://www.$1"
+          verifyPattern: "^https?(.+)" # There is a problem with the certificate so we use plain HTTP
+          verifyReplacement: "http$1"
+          required: true
 
         - source: "Asset Reference"
           dest: "image_full"


### PR DESCRIPTION
The URLConverter returned the input instead of the regexp-replaced result. This pull request fixes the problem and adds unit testing of `image_preview`, `image_full` and `iiif` fields.