### PR TITLE
Add support for forbiddenapis

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ The exporter requires a YAML stating Cumulus server, userid, password etc.
 Copy `src/test/resources/ds-cumulus-export.yml` to `user.home` and fill in the missing values.
 Contact a KB-developer on the DigiSam-project for the credentials.
 
+Also copy `src/test/resources/ds-cumulus-export-default-mapping.yml` to `user.home`.
+This file does not need to be adjusted.
+
 (the location of the config file will be made flexible at a later point)
 
 ## Build & run
@@ -45,6 +48,16 @@ When this is done, we can run
 mvn package
 java -cp /usr/local/Cumulus_Java_SDK/CumulusJC.jar:target/cumulus-export-0.1-SNAPSHOT-jar-with-dependencies.jar dk.kb.ds.cumulus.export.CumulusExport
 ```
+
+## Developer note
+
+The parent-pom for this project offers [forbiddenapis](https://github.com/policeman-tools/forbidden-apis),
+which checks for Java methods that are unsafe to use. One very common mistake is to use a
+Locale-dependent API without specifying a Locale, e.g. writing `String.format("%.1f", 0.999)`
+instead of `String.format(Locale.ENGLISH, "%.1f", 1.234);`: The output from the non-Locale
+version will depend on the platform it is running on.
+
+To check for forbidden APIs, run `mvn clean package forbiddenapis:check`.
 
 ## Status
 Skeleton structure & code only.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <parent>
       <groupId>dk.statsbiblioteket.sbprojects</groupId>
       <artifactId>sbprojects-parent</artifactId>
-      <version>17</version>
+      <version>18</version>
     </parent>
     <scm>
         <url>https://github.com/Det-Kongelige-Bibliotek/ds-cumulus-export</url>
@@ -203,15 +203,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
The https://github.com/policeman-tools/forbidden-apis project checks for unsafe Java API usage, primarily in the form of methods using the system's default charset and/or locale. The upgrade to parent pom version 18 enables support for this tool.

Run a forbidden APIs check with
`mvh clean package forbiddenapis:check`
(the check fails with the current code)