### PR TITLE
Digisam 192 enable forbiddenapi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
     <url>http://www.kb.dk</url>
 
     <parent>
-      <groupId>dk.statsbiblioteket.sbprojects</groupId>
-      <artifactId>sbprojects-parent</artifactId>
-      <version>18</version>
+      <groupId>org.sbforge</groupId>
+      <artifactId>sbforge-parent</artifactId>
+      <version>21</version>
     </parent>
     <scm>
         <url>https://github.com/Det-Kongelige-Bibliotek/ds-cumulus-export</url>
@@ -33,10 +33,17 @@
     </repositories>
 
     <properties>
-        <build.time>${maven.build.timestamp}</build.time>
-        <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
-        <java.main.class>dk.kb.ds.cumulus.export.CumulusExport</java.main.class>
-        <test.groups>fast</test.groups>
+      <build.time>${maven.build.timestamp}</build.time>
+      <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
+      <java.main.class>dk.kb.ds.cumulus.export.CumulusExport</java.main.class>
+      <test.groups>fast</test.groups>
+      <!-- Specify java version here, to support forbiddenapis plugin -->
+      <maven.compiler.source>11</maven.compiler.source>
+      <maven.compiler.target>11</maven.compiler.target>
+      <!-- Replace the line below with
+       <api.check.phase>none</api.check.phase>
+       to disable forbidden APIs check -->
+      <api.check.phase>process-classes</api.check.phase>
     </properties>
 
     <profiles>

--- a/src/main/java/dk/kb/ds/cumulus/export/CalendarUtils.java
+++ b/src/main/java/dk/kb/ds/cumulus/export/CalendarUtils.java
@@ -88,7 +88,7 @@ public class CalendarUtils {
     }
 
     private static final DateTimeFormatter WRITTEN_PARSER = DateTimeFormatter.
-        ofPattern("ccc LLL dd HH:mm:ss zzz yyyy", Locale.ROOT);
+        ofPattern("ccc LLL dd HH:mm:ss zzz yyyy", Locale.UK); // UK as we use ccc and LLL
     /**
      * Parses inputs with full date and time in written format.
      * @param datetime written time representation, e.g. 'Mon Jul 29 16:10:29 CEST 2019'.


### PR DESCRIPTION
Enables automatic check for `forbiddenapis` when the project is compiled or packaged, and switches to the public accessible parent-pom so that "everyone" should be able to build the project.

Also corrects an oversight from the review of DIGISAM-170.